### PR TITLE
Fixed Issue 74703603

### DIFF
--- a/upse_container_xsf.c
+++ b/upse_container_xsf.c
@@ -329,7 +329,9 @@ upse_time_to_ms(const char *str)
     s[99] = 0;
 
     for (x = strlen(s); x >= 0; x--)
-	if (s[x] == '.' || s[x] == ',')
+    	if (s[strlen(s)-1] == '0' && c == 0 && acc == 0)
+	    s[x]=0;
+	else if (s[x] == '.' || s[x] == ',')
 	{
 	    acc = atoi(s + x + 1);
 	    s[x] = 0;


### PR DESCRIPTION
Fixed the problem described in Issue 74703603. However, it does not fix the zeros in situations like 0.**00000**6 because it would no make sense, as a number of zeros bigger than 2 will result in a non-integer number, while the returned value of the function is an int (however, situations like 0.10006 are completely fixed, showing 1000600).