### PR TITLE
fix few possible Windows compile errors

### DIFF
--- a/upse-debug.h
+++ b/upse-debug.h
@@ -21,7 +21,7 @@
 #define _ENTER _DEBUG("enter")
 #define _LEAVE _DEBUG("leave")
 
-#ifndef WIN32_MSC
+#ifndef _MSC_VER
 
 #define _MESSAGE(tag, string, ...) do { fprintf(stderr, "libupse: %s: %s:%d (%s): " string "\n", \
     tag, __FILE__, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__); } while(0)

--- a/upse-types.h
+++ b/upse-types.h
@@ -18,13 +18,13 @@
 #ifndef _UPSE__LIBUPSE__UPSE_TYPES_H__GUARD
 #define _UPSE__LIBUPSE__UPSE_TYPES_H__GUARD
 
+#include <stdint.h>
 #ifndef _WIN32
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <unistd.h>
-#include <stdint.h>
 #else
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/upse_ps1_spu_base.c
+++ b/upse_ps1_spu_base.c
@@ -89,6 +89,9 @@ int upse_ps1_spu_seek(upse_module_instance_t *ins, u32 t)
 
 int upse_ps1_spu_render(upse_spu_state_t *spu, u32 cycles)
 {
+    if ( spu == NULL )
+      return (0);
+
     s32 dosampies;
     s32 temp;
 
@@ -132,6 +135,8 @@ int upse_ps1_spu_render(upse_spu_state_t *spu, u32 cycles)
 void upse_ps1_spu_stop(upse_module_instance_t *ins)
 {
     upse_spu_state_t *spu = ins->spu;
+    if ( spu == NULL )
+      return;
 
     spu->decaybegin = 1;
     spu->decayend = 0;


### PR DESCRIPTION
Since we are using this library with an addon (https://github.com/xbmc/audiodecoder.upse) in Kodi, a colleague had introduced some small fixes at the beginning.

This commit contains related changes.

Here are our error messages shown if change not used:
- https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.upse/detail/PR-12/1/pipeline/226
- https://dev.azure.com/teamkodi/binary-addons/_build/results?buildId=6152&view=results